### PR TITLE
Fix STEREO crib magnetic field load

### DIFF
--- a/idl/general/missions/stereo/st_crib.pro
+++ b/idl/general/missions/stereo/st_crib.pro
@@ -142,7 +142,7 @@ endif
    probe = 'b'
    dopad = 1
    if dopad then begin
-   st_mag_load,type=magres
+   st_mag_load,resolution='8hz'
 ;   xyz_to_polar,'st?_B_'+magres+'_SC'
 ;   xyz_to_polar,'st?_B_'+magres+'_RTN'
    options,'st?_B_*_inst_th',constant=[-60,60.],yrange=[-90,90],/ystyle


### PR DESCRIPTION
## Summary
- remove the unsupported `TYPE` keyword from the STEREO crib `st_mag_load` call
- request the intended/default 8 Hz magnetic-field resolution explicitly

Fixes #21

## Validation
- `rg -n 'st_mag_load,type' idl/general/missions/stereo/st_crib.pro` returns no matches
- checked `st_mag_load` signature: it accepts `resolution=res` and defaults `res` to `'8hz'`

## Review
- Zhipu/GLM review gate: reviewed before PR; no blocking findings; explicit `resolution='8hz'` polish applied
