### PR TITLE
Update tkm2re units metadata explicitly

### DIFF
--- a/idl/general/misc/tkm2re.pro
+++ b/idl/general/misc/tkm2re.pro
@@ -97,6 +97,10 @@ for i = 0,n_elements(names)-1 do begin
      str_element,data_att,'units',label,/add
      str_element,dl,'data_att',data_att,/add
    endelse
+
+   ; str_element may not update an existing nested units field in-place on
+   ; all IDL runtimes, so assign the ensured field explicitly.
+   dl.data_att.units = label
    
    str_element,dl,'ysubtitle',success=s    
    


### PR DESCRIPTION
## Summary
- explicitly update `dl.data_att.units` after the existing `str_element` block ensures the nested field exists
- keep the existing `str_element` structure but avoid relying on nested write-through behavior for existing units fields

Fixes #411

## Validation
- static check: `rg -n 'dl\.data_att\.units = label|str_element,dl\.data_att' idl/general/misc/tkm2re.pro`
- no IDL 9.0/Mac ARM64 runtime was available here, so I could not reproduce the platform-specific failure locally

## Review
- Zhipu/GLM review gate: reviewed before PR; no blocking findings; comment wording adjusted per review
