### PR TITLE
Warn on wildcard remote directories

### DIFF
--- a/idl/general/spedas_tools/spd_download/spd_download.pro
+++ b/idl/general/spedas_tools/spd_download/spd_download.pro
@@ -215,6 +215,23 @@ if n_elements(local_path) ne 1 then begin
 endif
 
 
+;warn when wildcard characters appear before the final remote path component
+;because the remote path is also used to derive local_file below
+if strpos(remote_path,'*') ne -1 || strpos(remote_path,'?') ne -1 || strpos(remote_path,'[') ne -1 then begin
+  dprint, dlevel=1, 'Warning: wildcard characters in remote directory components may produce unexpected local paths: ' + $
+    remote_path
+endif
+
+for i=0, n_elements(remote_file)-1 do begin
+  remote_dir = file_dirname(remote_file[i])
+  if remote_dir ne '.' && remote_dir ne '' then begin
+    if strpos(remote_dir,'*') ne -1 || strpos(remote_dir,'?') ne -1 || strpos(remote_dir,'[') ne -1 then begin
+      dprint, dlevel=1, 'Warning: wildcard characters in remote directory components may produce unexpected local paths: ' + $
+        remote_file[i]
+    endif
+  endif
+endfor
+
 ;complete remote file path(s)
 url = remote_path + remote_file
 


### PR DESCRIPTION
## Summary
- warn when `remote_path` contains wildcard characters before URL expansion
- warn when `remote_file` directory components contain wildcard characters
- keep existing behavior unchanged: the warning is informational and downloads still proceed

Fixes #142

## Validation
- static check: warning block appears before `url = remote_path + remote_file` and before `spd_download_expand`
- no IDL runtime was available here, so this was not runtime-reproduced locally

## Review
- Zhipu/GLM review gate: reviewed before PR; remote_path coverage added after review; no blocking findings
