### PR TITLE
Add mms_part_getspec support-variable override examples

### DIFF
--- a/idl/projects/mms/examples/advanced/mms_part_getspec_adv_crib.pro
+++ b/idl/projects/mms/examples/advanced/mms_part_getspec_adv_crib.pro
@@ -88,5 +88,42 @@ stop
 ; remove the solar wind component from the DIS DF data prior to performing the calculations
 mms_part_getspec, trange=['2016-12-07/14:40', '2016-12-07/15:15'], instrument='fpi', species='i', probe=1, /remove_fpi_sw
 tplot, 'mms1_dis_dist_fast_energy'
+stop
+
+; override the support-data tplot variables used by mms_part_getspec
+; mag_name should contain magnetic field data for pitch-angle/FAC products
+; use sc_pot_name (with underscores) for spacecraft potential data; scpot_name is not a keyword
+; vel_name should contain bulk velocity data in km/s for /subtract_bulk
+trange = ['2015-10-16/13:05:40', '2015-10-16/13:06:40']
+
+; load the default support data, then copy it to custom names to demonstrate
+; the override keyword syntax without changing the science inputs
+mms_load_fgm, probe=1, trange=trange, data_rate='brst', level='l2', $
+              varformat='*_fgm_b_gse_*', /time_clip
+mms_load_edp, probe=1, trange=trange, data_rate='brst', level='l2', $
+              datatype='scpot', varformat='*_edp_scpot_*', /time_clip
+tcopy, 'mms1_fgm_b_gse_brst_l2_bvec', 'mms1_custom_fgm_b_gse_brst_l2_bvec'
+tcopy, 'mms1_edp_scpot_brst_l2', 'mms1_custom_edp_scpot_brst_l2'
+
+mms_part_getspec, trange=trange, instrument='fpi', species='e', probe=1, $
+                  data_rate='brst', level='l2', output='pa moments', $
+                  suffix='_custom_support', $
+                  mag_name='mms1_custom_fgm_b_gse_brst_l2_bvec', $
+                  sc_pot_name='mms1_custom_edp_scpot_brst_l2'
+tplot, ['mms1_des_dist_brst_pa_custom_support', $
+        'mms1_des_dist_brst_density_custom_support']
+stop
+
+; vel_name is used when subtracting the bulk velocity from the distribution
+mms_load_fpi, probe=1, trange=trange, data_rate='brst', level='l2', $
+              datatype='dis-moms', /time_clip
+tcopy, 'mms1_dis_bulkv_gse_brst', 'mms1_custom_dis_bulkv_gse_brst'
+
+mms_part_getspec, trange=trange, instrument='fpi', species='i', probe=1, $
+                  data_rate='brst', level='l2', output='energy pa', $
+                  /subtract_bulk, suffix='_custom_vel', $
+                  vel_name='mms1_custom_dis_bulkv_gse_brst'
+tplot, ['mms1_dis_dist_brst_energy_custom_vel', $
+        'mms1_dis_dist_brst_pa_custom_vel']
 
 end


### PR DESCRIPTION
## Summary
- Add advanced crib examples showing how to pass custom support-data tplot variables to `mms_part_getspec`.
- Demonstrate `mag_name` and `sc_pot_name` for pitch-angle/moment products by copying default FGM/EDP support variables to custom names.
- Demonstrate `vel_name` with `/subtract_bulk` by copying the default DIS bulk velocity to a custom name.

## Notes
- The implemented spacecraft-potential keyword is `sc_pot_name` (with underscores), not `scpot_name`.
- The examples copy the default loaded support variables into custom names, so they demonstrate override syntax without changing the science inputs.

## Validation
- `git diff --check`
- Static checks for `mag_name`, `sc_pot_name`, and `vel_name` examples and expected support-variable copies
- Static source inspection confirmed `mms_part_getspec` and `mms_part_products` accept these keywords
- Zhipu/GLM review: no blockers; optional `sc_pot_name` spelling note applied
- IDL runtime was not available on my PATH, so no local IDL smoke run was performed

Closes #195.
